### PR TITLE
Make test the default task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,5 @@ Bundler.require
 task :test do
   Dir.glob('./test/**/*_test.rb') { |file| require file }
 end
+
+task default: :test


### PR DESCRIPTION
This allows module 1 students to simply type `rake` and the test run by default.